### PR TITLE
feat(marketplace): integrate curl quiz recommendations with product c…

### DIFF
--- a/app/(main)/carrito/page.tsx
+++ b/app/(main)/carrito/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+import { useCart } from "@/store/cartStore";
+import { useRouter } from "next/navigation";
+import { Trash2, ShoppingBag, ArrowLeft } from "lucide-react";
+
+export default function CarritoPage() {
+  const { items, removeItem, clear, total, count } = useCart();
+  const router = useRouter();
+
+  const totalTokens = items.reduce((s, i) => s + i.tokens * i.quantity, 0);
+
+  if (count === 0) {
+    return (
+      <div className="min-h-screen bg-[#FAF8F5] flex flex-col items-center justify-center px-4">
+        <span className="text-5xl mb-4">🛒</span>
+        <h2
+          className="text-xl font-bold text-[#3E2723] mb-2"
+          style={{ fontFamily: "var(--font-playfair)" }}
+        >
+          Tu carrito está vacío
+        </h2>
+        <p className="text-sm text-[#A1887F] mb-6">
+          Haz el quiz para descubrir tu rutina ideal
+        </p>
+        <button
+          onClick={() => router.push("/quiz")}
+          className="bg-[#8D6E63] text-white px-8 py-3 rounded-full text-sm font-medium hover:bg-[#6D4C41] transition-colors"
+        >
+          Hacer el quiz →
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#FAF8F5]">
+      <div className="max-w-lg mx-auto px-4 py-8">
+
+        <button
+          onClick={() => router.back()}
+          className="flex items-center gap-2 text-sm text-[#A1887F] hover:text-[#6D4C41] mb-6 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Volver
+        </button>
+
+        <div className="flex items-center justify-between mb-5">
+          <h1
+            className="text-2xl font-bold text-[#3E2723]"
+            style={{ fontFamily: "var(--font-playfair)" }}
+          >
+            Carrito
+          </h1>
+          <button
+            onClick={clear}
+            className="text-xs text-[#A1887F] hover:text-red-500 transition-colors"
+          >
+            Vaciar todo
+          </button>
+        </div>
+
+        <div className="space-y-3 mb-6">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className="bg-white rounded-2xl border border-[#D7CCC8] p-4 flex gap-4"
+            >
+              <div className="w-16 h-16 rounded-xl bg-[#EFEBE9] overflow-hidden flex-shrink-0">
+                <img
+                  src={item.imagen}
+                  alt={item.nombre}
+                  className="w-full h-full object-cover"
+                  onError={(e) => {
+                    (e.target as HTMLImageElement).src =
+                      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' fill='%23EFEBE9'%3E%3Crect width='64' height='64'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='24'%3E%F0%9F%A7%B4%3C/text%3E%3C/svg%3E";
+                  }}
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-xs text-[#A1887F]">{item.marca}</p>
+                <p
+                  className="text-sm font-semibold text-[#3E2723] line-clamp-2 mt-0.5"
+                  style={{ fontFamily: "var(--font-playfair)" }}
+                >
+                  {item.nombre}
+                </p>
+                <div className="flex items-center justify-between mt-2">
+                  <div>
+                    <span className="text-sm font-bold text-[#8D6E63]">
+                      ${(item.precioMXN * item.quantity).toLocaleString("es-MX")} MXN
+                    </span>
+                    {item.quantity > 1 && (
+                      <span className="text-xs text-[#A1887F] ml-1">×{item.quantity}</span>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => removeItem(item.id)}
+                    className="text-[#A1887F] hover:text-red-500 transition-colors"
+                    aria-label="Quitar producto"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Summary */}
+        <div className="bg-white rounded-2xl border border-[#D7CCC8] p-5 space-y-3 mb-4">
+          <div className="flex justify-between text-sm">
+            <span className="text-[#A1887F]">{count} producto{count !== 1 ? "s" : ""}</span>
+            <span className="font-bold text-[#3E2723]">${total.toLocaleString("es-MX")} MXN</span>
+          </div>
+          <div className="flex justify-between text-xs">
+            <span className="text-[#A1887F]">Tokens a ganar</span>
+            <span className="font-semibold text-[#8D6E63]">🪙 +{totalTokens} puntos</span>
+          </div>
+        </div>
+
+        <button
+          onClick={() => {
+            // Checkout handles one product at a time — for now go to tienda
+            router.push("/tienda");
+          }}
+          className="w-full flex items-center justify-center gap-2 bg-[#8D6E63] text-white py-4 rounded-2xl text-base font-semibold hover:bg-[#6D4C41] transition-colors"
+        >
+          <ShoppingBag className="w-5 h-5" />
+          Ir a la tienda a comprar
+        </button>
+        <p className="text-xs text-center text-[#A1887F] mt-3">
+          Selecciona cada producto en la tienda para completar tu compra
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/quiz/page.tsx
+++ b/app/(main)/quiz/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+const HAIR_TYPES = [
+  { id: "2a", label: "2A", titulo: "Ondulado suave", desc: "Ondas ligeras en S, cabello fino" },
+  { id: "2b", label: "2B", titulo: "Ondulado definido", desc: "Ondas marcadas, algo de volumen" },
+  { id: "2c", label: "2C", titulo: "Ondulado intenso", desc: "Ondas gruesas, propenso al frizz" },
+  { id: "3a", label: "3A", titulo: "Rizado amplio", desc: "Rizos grandes y elásticos" },
+  { id: "3b", label: "3B", titulo: "Rizado compacto", desc: "Rizos medianos con mucho volumen" },
+  { id: "3c", label: "3C", titulo: "Muy rizado", desc: "Rizos apretados tipo sacacorchos" },
+  { id: "4a", label: "4A", titulo: "Afro suave", desc: "Rizos muy apretados en forma de S" },
+  { id: "4b", label: "4B", titulo: "Afro angular", desc: "Patrón en zigzag, muy denso" },
+  { id: "4c", label: "4C", titulo: "Afro compacto", desc: "El rizo más apretado, máximo volumen" },
+];
+
+export default function QuizPage() {
+  const [selected, setSelected] = useState("");
+  const router = useRouter();
+
+  const handleVer = () => {
+    if (selected) router.push(`/quiz/resultado?tipo=${selected}`);
+  };
+
+  return (
+    <div className="min-h-screen bg-[#FAF8F5] flex flex-col items-center px-4 py-12">
+      <div className="w-full max-w-2xl">
+        <div className="mb-8 text-center">
+          <span className="text-3xl mb-3 block">🌀</span>
+          <h1
+            className="text-2xl md:text-3xl font-bold text-[#3E2723] mb-2"
+            style={{ fontFamily: "var(--font-playfair)" }}
+          >
+            ¿Cuál es tu tipo de rizo?
+          </h1>
+          <p className="text-[#A1887F] text-sm">
+            Selecciona tu tipo de cabello y te recomendaremos la rutina perfecta
+          </p>
+        </div>
+
+        <div className="w-full rounded-2xl overflow-hidden mb-6 border border-[#D7CCC8]">
+          <img src="/TipoRizo.jpeg" alt="Tipos de rizo" className="w-full object-cover" />
+        </div>
+
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-8">
+          {HAIR_TYPES.map((tipo) => (
+            <button
+              key={tipo.id}
+              onClick={() => setSelected(tipo.id)}
+              className="flex flex-col items-start p-4 rounded-2xl border-2 text-left transition-all"
+              style={{
+                borderColor: selected === tipo.id ? "#8D6E63" : "#D7CCC8",
+                backgroundColor: selected === tipo.id ? "#EFEBE9" : "white",
+              }}
+            >
+              <span
+                className="text-lg font-bold text-[#8D6E63] mb-1"
+                style={{ fontFamily: "var(--font-playfair)" }}
+              >
+                {tipo.label}
+              </span>
+              <p className="text-xs font-semibold text-[#3E2723]">{tipo.titulo}</p>
+              <p className="text-xs text-[#A1887F] mt-0.5">{tipo.desc}</p>
+              {selected === tipo.id && (
+                <span className="mt-2 text-xs font-medium text-[#8D6E63]">✓ Seleccionado</span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        <button
+          onClick={handleVer}
+          disabled={!selected}
+          className="w-full bg-[#8D6E63] text-white py-4 rounded-2xl text-base font-semibold hover:bg-[#6D4C41] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          Ver mi rutina personalizada →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/quiz/resultado/page.tsx
+++ b/app/(main)/quiz/resultado/page.tsx
@@ -1,0 +1,244 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { ShoppingCart, Check, ArrowLeft } from "lucide-react";
+import { useCart } from "@/store/cartStore";
+
+const MXN_PER_USDC = 19;
+
+type Product = {
+  id: string;
+  name: string;
+  brandName: string;
+  price: number;
+  tokenPrice: number;
+  imageUrl: string | null;
+  category: string | null;
+  hairTypes: string | null;
+  votes: number;
+};
+
+const HAIR_TYPE_LABELS: Record<string, string> = {
+  "2a": "2A — Ondulado suave",
+  "2b": "2B — Ondulado definido",
+  "2c": "2C — Ondulado intenso",
+  "3a": "3A — Rizado amplio",
+  "3b": "3B — Rizado compacto",
+  "3c": "3C — Muy rizado",
+  "4a": "4A — Afro suave",
+  "4b": "4B — Afro angular",
+  "4c": "4C — Afro compacto",
+};
+
+function StepBadge({ num, label }: { num: number; label: string }) {
+  return (
+    <div className="flex items-center gap-2 text-xs text-[#A1887F]">
+      <div className="w-5 h-5 rounded-full bg-[#8D6E63] text-white flex items-center justify-center text-[10px] font-bold flex-shrink-0">
+        {num}
+      </div>
+      <span>{label}</span>
+    </div>
+  );
+}
+
+export default function QuizResultadoPage() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const { addItems, count } = useCart();
+
+  const tipo = params.get("tipo") ?? "";
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [added, setAdded] = useState(false);
+
+  useEffect(() => {
+    if (!tipo) return;
+    setLoading(true);
+    fetch(`/api/quiz/recommendations?hairType=${encodeURIComponent(tipo)}`)
+      .then((r) => r.json())
+      .then((data) => setProducts(data.products ?? []))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [tipo]);
+
+  const handleAddRoutine = () => {
+    if (products.length === 0) return;
+    addItems(
+      products.map((p) => ({
+        id: p.id,
+        nombre: p.name,
+        marca: p.brandName,
+        precioMXN: Math.round(p.price * MXN_PER_USDC),
+        precioUSDC: p.price,
+        imagen: p.imageUrl ?? "",
+        tokens: p.tokenPrice,
+      }))
+    );
+    setAdded(true);
+    setTimeout(() => setAdded(false), 2500);
+  };
+
+  const totalMXN = products.reduce((s, p) => s + Math.round(p.price * MXN_PER_USDC), 0);
+  const totalTokens = products.reduce((s, p) => s + p.tokenPrice, 0);
+  const hairLabel = HAIR_TYPE_LABELS[tipo.toLowerCase()] ?? tipo.toUpperCase();
+
+  return (
+    <div className="min-h-screen bg-[#FAF8F5]">
+      <div className="max-w-2xl mx-auto px-4 py-8">
+
+        {/* Back */}
+        <button
+          onClick={() => router.push("/quiz")}
+          className="flex items-center gap-2 text-sm text-[#A1887F] hover:text-[#6D4C41] mb-6 transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Cambiar tipo de rizo
+        </button>
+
+        {/* Header */}
+        <div className="mb-6">
+          <p className="text-xs text-[#A1887F] font-medium mb-1">Tu rutina para</p>
+          <h1
+            className="text-2xl font-bold text-[#3E2723] mb-1"
+            style={{ fontFamily: "var(--font-playfair)" }}
+          >
+            {hairLabel}
+          </h1>
+          <p className="text-sm text-[#A1887F]">
+            Productos ordenados según tu rutina ideal — del más prioritario al complementario
+          </p>
+        </div>
+
+        {/* Routine steps legend */}
+        {!loading && products.length > 0 && (
+          <div className="bg-white rounded-2xl border border-[#D7CCC8] p-4 mb-5 flex flex-wrap gap-3">
+            {products.map((p, i) => (
+              <StepBadge key={p.id} num={i + 1} label={p.category ?? p.name} />
+            ))}
+          </div>
+        )}
+
+        {/* Product list */}
+        {loading ? (
+          <div className="space-y-3">
+            {[1, 2, 3].map((n) => (
+              <div key={n} className="bg-white rounded-2xl border border-[#D7CCC8] p-4 animate-pulse flex gap-4">
+                <div className="w-20 h-20 rounded-xl bg-[#EFEBE9] flex-shrink-0" />
+                <div className="flex-1 space-y-2 py-1">
+                  <div className="h-3 bg-[#EFEBE9] rounded w-16" />
+                  <div className="h-4 bg-[#EFEBE9] rounded w-3/4" />
+                  <div className="h-4 bg-[#EFEBE9] rounded w-1/2" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : products.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <span className="text-4xl mb-3">🔍</span>
+            <p className="text-sm font-semibold text-[#3E2723]">Sin productos para este tipo</p>
+            <p className="text-xs text-[#A1887F] mt-1">
+              Pronto habrá más productos disponibles en el catálogo
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3 mb-6">
+            {products.map((p, i) => (
+              <div
+                key={p.id}
+                className="bg-white rounded-2xl border border-[#D7CCC8] p-4 flex gap-4"
+              >
+                <div className="w-20 h-20 rounded-xl bg-[#EFEBE9] overflow-hidden flex-shrink-0">
+                  <img
+                    src={p.imageUrl ?? ""}
+                    alt={p.name}
+                    className="w-full h-full object-cover"
+                    onError={(e) => {
+                      (e.target as HTMLImageElement).src =
+                        "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80' fill='%23EFEBE9'%3E%3Crect width='80' height='80'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' font-size='28'%3E%F0%9F%A7%B4%3C/text%3E%3C/svg%3E";
+                    }}
+                  />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <p className="text-xs text-[#A1887F]">{p.brandName}</p>
+                      <h3
+                        className="text-sm font-semibold text-[#3E2723] leading-snug mt-0.5 line-clamp-2"
+                        style={{ fontFamily: "var(--font-playfair)" }}
+                      >
+                        {p.name}
+                      </h3>
+                    </div>
+                    <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[#EFEBE9] text-[#8D6E63] text-xs font-bold flex items-center justify-center">
+                      {i + 1}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 mt-2 flex-wrap">
+                    <span className="text-sm font-bold text-[#8D6E63]">
+                      ${Math.round(p.price * MXN_PER_USDC).toLocaleString("es-MX")} MXN
+                    </span>
+                    <span className="text-xs bg-[#EFEBE9] text-[#6D4C41] px-2 py-0.5 rounded-full">
+                      🪙 +{p.tokenPrice} pts
+                    </span>
+                    {p.category && (
+                      <span className="text-xs bg-[#FAF8F5] text-[#A1887F] border border-[#D7CCC8] px-2 py-0.5 rounded-full">
+                        {p.category}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Summary + CTA */}
+        {!loading && products.length > 0 && (
+          <div className="bg-white rounded-2xl border border-[#D7CCC8] p-5 space-y-4">
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-[#A1887F]">{products.length} productos en la rutina</span>
+              <span className="font-bold text-[#3E2723]">
+                ${totalMXN.toLocaleString("es-MX")} MXN
+              </span>
+            </div>
+            <div className="flex items-center justify-between text-xs text-[#A1887F]">
+              <span>Tokens que ganarás</span>
+              <span className="font-semibold text-[#8D6E63]">🪙 +{totalTokens} puntos</span>
+            </div>
+
+            <button
+              onClick={handleAddRoutine}
+              disabled={added}
+              className="w-full flex items-center justify-center gap-2 py-4 rounded-2xl text-base font-semibold transition-all"
+              style={{
+                backgroundColor: added ? "#4CAF50" : "#8D6E63",
+                color: "white",
+              }}
+            >
+              {added ? (
+                <>
+                  <Check className="w-5 h-5" />
+                  ¡Rutina agregada al carrito!
+                </>
+              ) : (
+                <>
+                  <ShoppingCart className="w-5 h-5" />
+                  Agregar rutina completa al carrito
+                </>
+              )}
+            </button>
+
+            {added && (
+              <button
+                onClick={() => router.push("/carrito")}
+                className="w-full text-center text-sm text-[#8D6E63] font-medium hover:underline"
+              >
+                Ver carrito ({count} producto{count !== 1 ? "s" : ""}) →
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -1,14 +1,27 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
-export async function GET() {
+export async function GET(req: NextRequest) {
+  const hairType = req.nextUrl.searchParams.get("hairType")?.toLowerCase();
+
   try {
     const products = await prisma.product.findMany({
-      orderBy: { createdAt: "desc" },
+      orderBy: { votes: "desc" },
     });
-    return NextResponse.json(products);
+
+    const filtered = hairType
+      ? products.filter((p) => {
+          if (!p.hairTypes) return false;
+          return p.hairTypes
+            .split(",")
+            .map((t) => t.trim().toLowerCase())
+            .includes(hairType);
+        })
+      : products;
+
+    return NextResponse.json(filtered);
   } catch (error) {
     console.error("[/api/products]", error);
     return NextResponse.json(

--- a/app/api/quiz/recommendations/route.ts
+++ b/app/api/quiz/recommendations/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+// Maps hair type prefix to recommended category order for a routine
+const ROUTINE_ORDER: Record<string, string[]> = {
+  "2": ["Co-wash", "Shampoo", "Acondicionador", "Leave-in", "Definidores", "Geles", "Crema"],
+  "3": ["Shampoo", "Acondicionador", "Leave-in", "Crema", "Definidores", "Geles", "Aceites"],
+  "4": ["Shampoo", "Acondicionador", "Leave-in", "Mascarilla", "Mantequillas", "Definidores", "Aceites"],
+};
+
+export async function GET(req: NextRequest) {
+  const hairType = req.nextUrl.searchParams.get("hairType")?.toLowerCase();
+
+  if (!hairType) {
+    return NextResponse.json({ error: "hairType requerido" }, { status: 400 });
+  }
+
+  try {
+    const allProducts = await prisma.product.findMany({
+      orderBy: { votes: "desc" },
+    });
+
+    // Filter products that include this hair type
+    const matching = allProducts.filter((p) => {
+      if (!p.hairTypes) return false;
+      return p.hairTypes
+        .split(",")
+        .map((t) => t.trim().toLowerCase())
+        .includes(hairType);
+    });
+
+    // Build a routine: one product per category, in recommended order
+    const prefix = hairType[0]; // "2", "3", or "4"
+    const order = ROUTINE_ORDER[prefix] ?? ROUTINE_ORDER["3"];
+
+    const routine: typeof matching = [];
+    const usedIds = new Set<string>();
+
+    // First pass: pick best product per category in routine order
+    for (const cat of order) {
+      const pick = matching.find(
+        (p) => p.category?.toLowerCase() === cat.toLowerCase() && !usedIds.has(p.id)
+      );
+      if (pick) {
+        routine.push(pick);
+        usedIds.add(pick.id);
+      }
+    }
+
+    // Second pass: add remaining matched products not yet in routine
+    for (const p of matching) {
+      if (!usedIds.has(p.id)) routine.push(p);
+    }
+
+    return NextResponse.json({ hairType, products: routine });
+  } catch (error) {
+    console.error("[/api/quiz/recommendations]", error);
+    return NextResponse.json({ error: "Error interno" }, { status: 500 });
+  }
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -2,6 +2,7 @@
 import { AcceslyProvider, useAccesly } from "accesly";
 import { useEffect, useRef } from "react";
 import { useRouter, usePathname } from "next/navigation";
+import { CartProvider } from "@/store/cartStore";
 
 function AuthHandler({ children }: { children: React.ReactNode }) {
   const { wallet } = useAccesly();
@@ -51,7 +52,9 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       network="testnet"
       theme="light"
     >
-      <AuthHandler>{children}</AuthHandler>
+      <CartProvider>
+        <AuthHandler>{children}</AuthHandler>
+      </CartProvider>
     </AcceslyProvider>
   );
 }

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -4,10 +4,13 @@ import { useState } from "react";
 import { useAccesly } from "accesly";
 import AuthModal from "@/components/layout/AuthModal";
 import { useSession, signOut } from "next-auth/react";
+import { ShoppingCart } from "lucide-react";
+import { useCart } from "@/store/cartStore";
 
 const linksBase = [
   { label: "Comunidad",    href: "/comunidad" },
   { label: "Tienda",       href: "/tienda" },
+  { label: "Quiz de Rizos", href: "/quiz" },
   { label: "Profesionales", href: "/estilistas" },
 ];
 
@@ -27,6 +30,7 @@ export default function Navbar() {
   const userInicial = wallet?.email?.[0]?.toUpperCase()
     || session?.user?.name?.[0]?.toUpperCase()
     || "U";
+  const { count: cartCount } = useCart();
 
   const handleDesconectar = () => {
     setDropdownOpen(false);
@@ -66,6 +70,15 @@ export default function Navbar() {
 
           {/* Derecha */}
           <div className="hidden md:flex items-center gap-3">
+            {/* Cart icon */}
+            <Link href="/carrito" className="relative w-8 h-8 flex items-center justify-center text-[#4E342E] hover:text-[#8D6E63] transition-colors">
+              <ShoppingCart className="w-5 h-5" />
+              {cartCount > 0 && (
+                <span className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-[#8D6E63] text-white text-[9px] font-bold flex items-center justify-center">
+                  {cartCount > 9 ? "9+" : cartCount}
+                </span>
+              )}
+            </Link>
             {estaLogueado ? (
               <div className="relative">
                 <button
@@ -136,6 +149,11 @@ export default function Navbar() {
                 Entrar
               </button>
             )}
+            <Link href="/carrito" onClick={() => setMenuOpen(false)}
+              className="flex items-center gap-2 text-sm text-[#4E342E]">
+              <ShoppingCart className="w-4 h-4" />
+              Carrito {cartCount > 0 && <span className="bg-[#8D6E63] text-white text-xs px-1.5 py-0.5 rounded-full">{cartCount}</span>}
+            </Link>
           </div>
         )}
       </nav>

--- a/store/cartStore.tsx
+++ b/store/cartStore.tsx
@@ -1,0 +1,108 @@
+"use client";
+import { createContext, useContext, useEffect, useReducer, ReactNode } from "react";
+
+export type CartItem = {
+  id: string;
+  nombre: string;
+  marca: string;
+  precioMXN: number;
+  precioUSDC: number;
+  imagen: string;
+  tokens: number;
+  quantity: number;
+};
+
+type CartState = { items: CartItem[] };
+
+type Action =
+  | { type: "ADD_ITEMS"; items: Omit<CartItem, "quantity">[] }
+  | { type: "ADD_ITEM"; item: Omit<CartItem, "quantity"> }
+  | { type: "REMOVE_ITEM"; id: string }
+  | { type: "CLEAR" }
+  | { type: "LOAD"; items: CartItem[] };
+
+function reducer(state: CartState, action: Action): CartState {
+  switch (action.type) {
+    case "LOAD":
+      return { items: action.items };
+    case "ADD_ITEM": {
+      const exists = state.items.find((i) => i.id === action.item.id);
+      return {
+        items: exists
+          ? state.items.map((i) =>
+              i.id === action.item.id ? { ...i, quantity: i.quantity + 1 } : i
+            )
+          : [...state.items, { ...action.item, quantity: 1 }],
+      };
+    }
+    case "ADD_ITEMS": {
+      const merged = [...state.items];
+      for (const item of action.items) {
+        const idx = merged.findIndex((i) => i.id === item.id);
+        if (idx >= 0) merged[idx] = { ...merged[idx], quantity: merged[idx].quantity + 1 };
+        else merged.push({ ...item, quantity: 1 });
+      }
+      return { items: merged };
+    }
+    case "REMOVE_ITEM":
+      return { items: state.items.filter((i) => i.id !== action.id) };
+    case "CLEAR":
+      return { items: [] };
+    default:
+      return state;
+  }
+}
+
+const CartContext = createContext<{
+  items: CartItem[];
+  addItem: (item: Omit<CartItem, "quantity">) => void;
+  addItems: (items: Omit<CartItem, "quantity">[]) => void;
+  removeItem: (id: string) => void;
+  clear: () => void;
+  total: number;
+  count: number;
+} | null>(null);
+
+const STORAGE_KEY = "rizo_cart";
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, { items: [] });
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) dispatch({ type: "LOAD", items: JSON.parse(saved) });
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state.items));
+    } catch {}
+  }, [state.items]);
+
+  const total = state.items.reduce((s, i) => s + i.precioMXN * i.quantity, 0);
+  const count = state.items.reduce((s, i) => s + i.quantity, 0);
+
+  return (
+    <CartContext.Provider
+      value={{
+        items: state.items,
+        addItem: (item) => dispatch({ type: "ADD_ITEM", item }),
+        addItems: (items) => dispatch({ type: "ADD_ITEMS", items }),
+        removeItem: (id) => dispatch({ type: "REMOVE_ITEM", id }),
+        clear: () => dispatch({ type: "CLEAR" }),
+        total,
+        count,
+      }}
+    >
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export function useCart() {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error("useCart must be used within CartProvider");
+  return ctx;
+}


### PR DESCRIPTION
Closes #26 

…atalog

- Add CartProvider with localStorage-backed persistent cart state
- Update GET /api/products to support ?hairType= filtering via Prisma
- Add GET /api/quiz/recommendations route: maps hair type profiles (2A-4C) to ordered product routines by type prefix (2/3/4) and category priority
- Add /quiz page: hair type selector grid (2A-4C) with TipoRizo image guide
- Add /quiz/resultado page: fetches dynamic recommendations, displays ordered routine with step numbers, totals, and Add routine to cart button
- Add /carrito page: persistent cart view with item list, totals, token summary
- Update Navbar: add Quiz de Rizos link and cart icon with live count badge