### PR TITLE
feat: add SBT credentials UI for stylist profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,10 @@ LOYALTY_CONTRACT_ID=""
 # such as get_balance() and check_discount(). Must match LOYALTY_CONTRACT_ID.
 NEXT_PUBLIC_LOYALTY_CONTRACT_ID=""
 
+# Soroban smart contract ID for stylist credentials (Soulbound Tokens / SBT).
+# Used server-side to query and request on-chain credentials for professionals.
+SBT_CONTRACT_ID=""
+
 
 # =============================================================================
 # DOCKER — Local Development Only

--- a/app/api/credentials/route.ts
+++ b/app/api/credentials/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CREDENTIAL_TYPES,
+  type CredentialType,
+  getCredentials,
+  requestCredential,
+} from "@/lib/sbtContract";
+
+function isCredentialType(value: unknown): value is CredentialType {
+  return typeof value === "string" && CREDENTIAL_TYPES.includes(value as CredentialType);
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const wallet = req.nextUrl.searchParams.get("wallet");
+    if (!wallet) {
+      return NextResponse.json({ error: "Wallet requerida" }, { status: 400 });
+    }
+
+    const credentials = await getCredentials(wallet);
+    return NextResponse.json({ credentials });
+  } catch (error) {
+    console.error("[/api/credentials][GET]", error);
+    return NextResponse.json({ credentials: [] }, { status: 200 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const wallet = body?.wallet as string | undefined;
+    const credentialType = body?.credentialType;
+
+    if (!wallet || !isCredentialType(credentialType)) {
+      return NextResponse.json(
+        { error: "wallet y credentialType son requeridos" },
+        { status: 400 }
+      );
+    }
+
+    await requestCredential(wallet, credentialType);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[/api/credentials][POST]", error);
+    return NextResponse.json(
+      { error: "No se pudo iniciar la solicitud de credencial" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/profesionales/CredentialCard.tsx
+++ b/components/profesionales/CredentialCard.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { CheckCircle2, CalendarDays } from "lucide-react";
+import { ReactNode } from "react";
+
+type CredentialCardProps = {
+  specialization: string;
+  dateObtained: string;
+  icon: ReactNode;
+  verified?: boolean;
+};
+
+function formatDate(dateValue: string): string {
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.getTime())) return "Fecha no disponible";
+  return date.toLocaleDateString("es-MX", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function CredentialCard({
+  specialization,
+  dateObtained,
+  icon,
+  verified = true,
+}: CredentialCardProps) {
+  return (
+    <article className="bg-white rounded-2xl border border-[#D7CCC8] p-5">
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div className="w-12 h-12 rounded-xl bg-[#EFEBE9] border border-[#D7CCC8] flex items-center justify-center text-[#8D6E63] shrink-0">
+          {icon}
+        </div>
+        {verified && (
+          <span className="inline-flex items-center gap-1 bg-[#E1F5EE] text-[#0F6E56] text-xs font-medium px-2.5 py-1 rounded-full">
+            <CheckCircle2 className="w-3.5 h-3.5" />
+            Verificada on-chain
+          </span>
+        )}
+      </div>
+
+      <h3
+        className="text-base font-semibold text-[#3E2723] mb-2"
+        style={{ fontFamily: "var(--font-playfair)" }}
+      >
+        {specialization}
+      </h3>
+
+      <div className="inline-flex items-center gap-1.5 text-xs text-[#A1887F]">
+        <CalendarDays className="w-3.5 h-3.5" />
+        Obtenida: {formatDate(dateObtained)}
+      </div>
+    </article>
+  );
+}

--- a/components/profile/CredentialsTab.tsx
+++ b/components/profile/CredentialsTab.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Leaf, Palette, Sparkles, Wind, BadgeCheck, Send } from "lucide-react";
+import CredentialCard from "@/components/profesionales/CredentialCard";
+import { CREDENTIAL_TYPES, type CredentialType } from "@/lib/sbtContract";
+
+type CredentialItem = {
+  type: CredentialType;
+  dateObtained: string;
+  verified: boolean;
+};
+
+const CREDENTIAL_METADATA: Record<
+  CredentialType,
+  { label: string; icon: React.ComponentType<{ className?: string }> }
+> = {
+  curl_specialist: { label: "Especialista en Rizos", icon: Sparkles },
+  natural_hair: { label: "Cabello Natural", icon: Leaf },
+  loc_stylist: { label: "Estilista de Locs", icon: Wind },
+  color_specialist: { label: "Especialista en Color", icon: Palette },
+};
+
+type CredentialsTabProps = {
+  walletAddress?: string | null;
+};
+
+export default function CredentialsTab({ walletAddress }: CredentialsTabProps) {
+  const [credentials, setCredentials] = useState<CredentialItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [requesting, setRequesting] = useState(false);
+  const [selectedType, setSelectedType] = useState<CredentialType>("curl_specialist");
+  const [showRequestPanel, setShowRequestPanel] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchCredentials = async () => {
+      if (!walletAddress) {
+        setCredentials([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/credentials?wallet=${encodeURIComponent(walletAddress)}`);
+        const data = await res.json();
+        setCredentials(Array.isArray(data.credentials) ? data.credentials : []);
+      } catch {
+        setCredentials([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void fetchCredentials();
+  }, [walletAddress]);
+
+  const requestedTypes = useMemo(
+    () => new Set(credentials.map((credential) => credential.type)),
+    [credentials]
+  );
+
+  const canRequest = Boolean(walletAddress);
+
+  const requestCredential = async () => {
+    if (!walletAddress || requesting) return;
+
+    setRequesting(true);
+    setFeedback(null);
+    try {
+      const res = await fetch("/api/credentials", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          wallet: walletAddress,
+          credentialType: selectedType,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Solicitud no iniciada");
+      }
+
+      setFeedback("Solicitud enviada. Revisaremos tu credencial pronto.");
+      setShowRequestPanel(false);
+    } catch {
+      setFeedback("No pudimos enviar la solicitud. Intenta de nuevo.");
+    } finally {
+      setRequesting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <div className="w-8 h-8 border-2 border-[#8D6E63] border-t-transparent rounded-full animate-spin mb-4" />
+        <p className="text-sm text-[#A1887F]">Consultando credenciales on-chain...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3 flex-wrap mb-5">
+        <h2
+          className="text-lg font-bold text-[#3E2723]"
+          style={{ fontFamily: "var(--font-playfair)" }}
+        >
+          Credenciales verificadas
+        </h2>
+        <button
+          onClick={() => setShowRequestPanel((prev) => !prev)}
+          disabled={!canRequest}
+          className="inline-flex items-center gap-2 bg-[#8D6E63] text-white px-4 py-2 rounded-full text-sm font-medium hover:bg-[#6D4C41] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          <Send className="w-4 h-4" />
+          Solicitar credencial
+        </button>
+      </div>
+
+      {showRequestPanel && (
+        <div className="bg-white rounded-2xl border border-[#D7CCC8] p-4 mb-6">
+          <label className="block text-xs text-[#A1887F] mb-2">Tipo de credencial</label>
+          <div className="flex gap-3 flex-wrap">
+            <select
+              value={selectedType}
+              onChange={(e) => setSelectedType(e.target.value as CredentialType)}
+              className="min-w-56 rounded-xl border border-[#D7CCC8] bg-[#FAF8F5] px-3 py-2 text-sm text-[#3E2723] focus:outline-none focus:ring-2 focus:ring-[#8D6E63]/20"
+            >
+              {CREDENTIAL_TYPES.map((type) => (
+                <option
+                  key={type}
+                  value={type}
+                  disabled={requestedTypes.has(type)}
+                >
+                  {CREDENTIAL_METADATA[type].label}
+                  {requestedTypes.has(type) ? " (ya obtenida)" : ""}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={requestCredential}
+              disabled={requesting}
+              className="bg-[#8D6E63] text-white px-4 py-2 rounded-xl text-sm font-medium hover:bg-[#6D4C41] transition-colors disabled:opacity-60"
+            >
+              {requesting ? "Enviando..." : "Enviar solicitud"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {feedback && (
+        <p className="text-sm text-[#6D4C41] mb-4">{feedback}</p>
+      )}
+
+      {credentials.length === 0 ? (
+        <div className="bg-white rounded-2xl border border-[#D7CCC8] py-16 px-6 text-center">
+          <div className="w-12 h-12 mx-auto rounded-xl bg-[#EFEBE9] border border-[#D7CCC8] flex items-center justify-center mb-4">
+            <BadgeCheck className="w-6 h-6 text-[#8D6E63]" />
+          </div>
+          <p
+            className="text-base font-semibold text-[#3E2723]"
+            style={{ fontFamily: "var(--font-playfair)" }}
+          >
+            Aun no tienes credenciales verificadas
+          </p>
+          <p className="text-sm text-[#A1887F] mt-1">
+            Solicita tu primera certificacion y destaca tu especializacion para toda la comunidad.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {credentials.map((credential) => {
+            const meta = CREDENTIAL_METADATA[credential.type];
+            const Icon = meta.icon;
+            return (
+              <CredentialCard
+                key={`${credential.type}-${credential.dateObtained}`}
+                specialization={meta.label}
+                dateObtained={credential.dateObtained}
+                icon={<Icon className="w-5 h-5" />}
+                verified={credential.verified}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/profile/PerfilPage.tsx
+++ b/components/profile/PerfilPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import { useAccesly } from "accesly";
 import Link from "next/link";
+import CredentialsTab from "@/components/profile/CredentialsTab";
 
 type UserProfile = {
   id: string;
@@ -13,6 +14,7 @@ type UserProfile = {
   role: string;
   tokens: number;
   avatar: string | null;
+  stellarPublicKey: string | null;
   onboardingCompleted: boolean;
   _count: { posts: number; reviews: number };
 };
@@ -26,7 +28,9 @@ const ROLE_LABELS: Record<string, { label: string; color: string }> = {
 export default function PerfilPage() {
   const { data: session } = useSession();
   const { wallet } = useAccesly();
-  const [tab, setTab] = useState<"publicaciones" | "resenas" | "guardados">("publicaciones");
+  const [tab, setTab] = useState<
+    "publicaciones" | "resenas" | "guardados" | "credenciales"
+  >("publicaciones");
   const [perfil, setPerfil] = useState<UserProfile | null>(null);
   const [cargando, setCargando] = useState(true);
 
@@ -34,9 +38,17 @@ export default function PerfilPage() {
   const userInicial = perfil?.name?.[0]?.toUpperCase() || userEmail?.[0]?.toUpperCase() || "?";
   const username = perfil?.email?.split("@")[0] || "";
   const roleInfo = ROLE_LABELS[perfil?.role ?? "RIZADA"] ?? ROLE_LABELS.RIZADA;
+  const tabs: Array<{ id: typeof tab; label: string }> = [
+    { id: "publicaciones", label: "Publicaciones" },
+    { id: "resenas", label: "Resenas" },
+    { id: "guardados", label: "Guardados" },
+    ...(perfil?.role === "ESTILISTA"
+      ? [{ id: "credenciales" as const, label: "Credenciales" }]
+      : []),
+  ];
 
   useEffect(() => {
-    if (!userEmail) { setCargando(false); return; }
+    if (!userEmail) return;
     fetch(`/api/user/me?email=${encodeURIComponent(userEmail)}`)
       .then((r) => r.json())
       .then((data) => { if (data.id) setPerfil(data); })
@@ -149,12 +161,8 @@ export default function PerfilPage() {
 
       {/* Tabs */}
       <div className="flex gap-1 bg-white rounded-2xl p-1 border border-[#D7CCC8] mb-6">
-        {[
-          { id: "publicaciones", label: "Publicaciones" },
-          { id: "resenas", label: "Resenas" },
-          { id: "guardados", label: "Guardados" },
-        ].map((t) => (
-          <button key={t.id} onClick={() => setTab(t.id as typeof tab)}
+        {tabs.map((t) => (
+          <button key={t.id} onClick={() => setTab(t.id)}
             className="flex-1 py-2.5 rounded-xl text-sm font-medium transition-all"
             style={{
               backgroundColor: tab === t.id ? "#8D6E63" : "transparent",
@@ -194,6 +202,10 @@ export default function PerfilPage() {
           <p className="text-sm font-semibold text-[#3E2723]">No tienes guardados aun</p>
           <p className="text-xs text-[#A1887F] mt-1">Guarda publicaciones y productos para verlos aqui</p>
         </div>
+      )}
+
+      {tab === "credenciales" && perfil?.role === "ESTILISTA" && (
+        <CredentialsTab walletAddress={perfil?.stellarPublicKey} />
       )}
 
     </div>

--- a/lib/sbtContract.ts
+++ b/lib/sbtContract.ts
@@ -1,0 +1,190 @@
+/**
+ * lib/sbtContract.ts
+ * Cliente para contrato Soroban de credenciales SBT.
+ * SERVER-SIDE ONLY — no importar desde componentes cliente.
+ */
+
+import {
+  rpc as SorobanRpc,
+  Contract,
+  TransactionBuilder,
+  Networks,
+  BASE_FEE,
+  Keypair,
+  Address,
+  scValToNative,
+  Transaction,
+  xdr,
+} from "@stellar/stellar-sdk";
+
+const SOROBAN_RPC = "https://soroban-testnet.stellar.org";
+const NETWORK_PASSPHRASE = Networks.TESTNET;
+
+export const CREDENTIAL_TYPES = [
+  "curl_specialist",
+  "natural_hair",
+  "loc_stylist",
+  "color_specialist",
+] as const;
+
+export type CredentialType = (typeof CREDENTIAL_TYPES)[number];
+
+export type SbtCredential = {
+  type: CredentialType;
+  dateObtained: string;
+  verified: boolean;
+};
+
+function getContractId(): string {
+  const id = process.env.SBT_CONTRACT_ID;
+  if (!id) throw new Error("SBT_CONTRACT_ID no esta configurado en .env.local");
+  return id;
+}
+
+function getRpcServer(): SorobanRpc.Server {
+  return new SorobanRpc.Server(SOROBAN_RPC, { allowHttp: false });
+}
+
+function credentialTypeToScVal(credentialType: CredentialType): xdr.ScVal {
+  return xdr.ScVal.scvSymbol(credentialType);
+}
+
+async function submitTx(
+  methodName: string,
+  args: xdr.ScVal[],
+  signerSecret: string
+): Promise<void> {
+  const server = getRpcServer();
+  const keypair = Keypair.fromSecret(signerSecret);
+  const account = await server.getAccount(keypair.publicKey());
+  const contract = new Contract(getContractId());
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(methodName, ...args))
+    .setTimeout(30)
+    .build();
+
+  const prepared = (await server.prepareTransaction(tx)) as Transaction;
+  prepared.sign(keypair);
+
+  const sendResult = await server.sendTransaction(prepared);
+  if (sendResult.status === "ERROR") {
+    throw new Error(`[sbt] submitTx error: ${JSON.stringify(sendResult)}`);
+  }
+
+  for (let i = 0; i < 10; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    const response = await server.getTransaction(sendResult.hash);
+    if (response.status === SorobanRpc.Api.GetTransactionStatus.SUCCESS) return;
+    if (response.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+      throw new Error(`[sbt] transaccion fallida: ${sendResult.hash}`);
+    }
+  }
+}
+
+async function simulateRead(
+  methodName: string,
+  args: xdr.ScVal[]
+): Promise<ReturnType<typeof scValToNative> | null> {
+  const server = getRpcServer();
+  const issuerPublicKey = process.env.STELLAR_ISSUER_PUBLIC_KEY;
+  if (!issuerPublicKey) throw new Error("STELLAR_ISSUER_PUBLIC_KEY no configurado");
+
+  const account = await server.getAccount(issuerPublicKey);
+  const contract = new Contract(getContractId());
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(methodName, ...args))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+  if (SorobanRpc.Api.isSimulationError(result)) {
+    throw new Error(`[sbt] simulateRead error: ${result.error}`);
+  }
+
+  if (!result.result?.retval) return null;
+  return scValToNative(result.result.retval);
+}
+
+function isCredentialType(value: unknown): value is CredentialType {
+  return typeof value === "string" && CREDENTIAL_TYPES.includes(value as CredentialType);
+}
+
+function parseContractCredentials(raw: unknown): SbtCredential[] {
+  if (!Array.isArray(raw)) return [];
+
+  const parsed: SbtCredential[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+
+    const record = item as Record<string, unknown>;
+    const typeValue = record.type ?? record.credential_type ?? record.credentialType;
+    if (!isCredentialType(typeValue)) continue;
+
+    const obtainedValue = record.date_obtained ?? record.dateObtained ?? record.obtained_at;
+    const asDate =
+      typeof obtainedValue === "string"
+        ? obtainedValue
+        : typeof obtainedValue === "number"
+          ? new Date(obtainedValue * 1000).toISOString()
+          : new Date().toISOString();
+
+    parsed.push({
+      type: typeValue,
+      dateObtained: asDate,
+      verified: true,
+    });
+  }
+
+  return parsed;
+}
+
+export async function getCredentials(userPublicKey: string): Promise<SbtCredential[]> {
+  try {
+    const val = await simulateRead("get_credentials", [
+      new Address(userPublicKey).toScVal(),
+    ]);
+    const parsed = parseContractCredentials(val);
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+export async function hasCredential(
+  userPublicKey: string,
+  credentialType: CredentialType
+): Promise<boolean> {
+  try {
+    const val = await simulateRead("has_credential", [
+      new Address(userPublicKey).toScVal(),
+      credentialTypeToScVal(credentialType),
+    ]);
+    return Boolean(val);
+  } catch {
+    return false;
+  }
+}
+
+export async function requestCredential(
+  userPublicKey: string,
+  credentialType: CredentialType
+): Promise<void> {
+  const issuerSecret = process.env.STELLAR_ISSUER_SECRET_KEY;
+  if (!issuerSecret) {
+    throw new Error("STELLAR_ISSUER_SECRET_KEY no configurado");
+  }
+
+  await submitTx(
+    "request_credential",
+    [new Address(userPublicKey).toScVal(), credentialTypeToScVal(credentialType)],
+    issuerSecret
+  );
+}


### PR DESCRIPTION
## Summary
- add a role-gated `Credenciales` tab on `/perfil` visible only for `ESTILISTA` profiles
- add `CredentialCard` and `CredentialsTab` UI for verified on-chain specializations with loading and empty states
- add Soroban SBT integration via `lib/sbtContract.ts` and `/api/credentials` GET/POST endpoints, plus `SBT_CONTRACT_ID` env template

## Test plan
- [x] Confirm `Credenciales` tab is hidden for non-`ESTILISTA` roles
- [x] Confirm `Credenciales` tab appears for `ESTILISTA` roles
- [x] Confirm loading spinner displays while credentials are fetched
- [x] Confirm motivational empty state is shown when no credentials exist
- [x] Confirm "Solicitar credencial" triggers POST `/api/credentials`
- [x] Confirm changed files pass targeted eslint checks
- [ ] End-to-end on-chain verification once issue #3 SBT contract is deployed

closes #11